### PR TITLE
Allow custom fields in devise_token_auth sign up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,11 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
   skip_before_action :verify_authenticity_token, if: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name])
+  end
 end


### PR DESCRIPTION
### Summary
- Fix a bug when a user will create an account, devise_token_auth refuses first_name and last_name fields

### Trello Card
It does not belong to a card