### PR TITLE
Add I18n support for Rent confirmation email

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,6 +5,11 @@ module Api
 
       protect_from_forgery with: :null_session
       before_action :authenticate_api_v1_user!
+      before_action :set_locale
+
+      def set_locale
+        I18n.default_locale = current_api_v1_user.locale
+      end
     end
   end
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -8,7 +8,7 @@ module Api
       before_action :set_locale
 
       def set_locale
-        I18n.default_locale = current_api_v1_user.locale
+        I18n.default_locale = current_api_v1_user.locale || :en
       end
     end
   end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,11 +5,7 @@ module Api
 
       protect_from_forgery with: :null_session
       before_action :authenticate_api_v1_user!
-      before_action :set_locale
 
-      def set_locale
-        I18n.locale = current_api_v1_user.locale || I18n.default_locale
-      end
     end
   end
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,7 +5,6 @@ module Api
 
       protect_from_forgery with: :null_session
       before_action :authenticate_api_v1_user!
-
     end
   end
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,6 +5,11 @@ module Api
 
       protect_from_forgery with: :null_session
       before_action :authenticate_api_v1_user!
+      before_action :set_locale
+
+      def set_locale
+        I18n.locale = current_api_v1_user.locale || I18n.default_locale
+      end
     end
   end
 end

--- a/app/mailers/rent_mailer.rb
+++ b/app/mailers/rent_mailer.rb
@@ -4,6 +4,9 @@ class RentMailer < ApplicationMailer
     @rent = Rent.find(rent_id)
     @user = @rent.user
     @book = @rent.book
+
+    I18n.locale = @user.locale || I18n.default_locale
+
     mail(to: @user.email, subject: 'Rent Confirmation Email')
   end
 end

--- a/app/mailers/rent_mailer.rb
+++ b/app/mailers/rent_mailer.rb
@@ -5,8 +5,6 @@ class RentMailer < ApplicationMailer
     @user = @rent.user
     @book = @rent.book
 
-    I18n.locale = @user.locale || I18n.default_locale
-
     mail(to: @user.email, subject: 'Rent Confirmation Email')
   end
 end

--- a/app/views/rent_mailer/rent_confirmation.html.slim
+++ b/app/views/rent_mailer/rent_confirmation.html.slim
@@ -1,14 +1,26 @@
-h1 = t('.title' , title: @book.title)
+h1
+  = t('.title' , title: @book.title)
 
-h4 = t('.subtitle', name: @user.first_name, title: @book.title)
+h4
+  = t('.subtitle', name: @user.first_name, title: @book.title)
 
-p = t('.info')
+p
+  = t('.info')
+
 ul
-  li = t('.author', author: @book.author)
-  li = t('.publisher', publisher: @book.publisher)
-  li = t('.year', year: @book.year)
-  li = t('.genre', genre: @book.genre)
+  li
+    = t('.author', author: @book.author)
+  li
+    = t('.publisher', publisher: @book.publisher)
+  li
+    = t('.year', year: @book.year)
+  li
+    = t('.genre', genre: @book.genre)
 
-p = t('.foot1', from: @rent.from_date, to: @rent.to_date)
+p
+  = t('.foot1', from: @rent.from_date, to: @rent.to_date)
+
 hr
-p = t('.foot2', created_at: @rent.created_at)
+
+p
+  = t('.foot2', created_at: @rent.created_at)

--- a/app/views/rent_mailer/rent_confirmation.html.slim
+++ b/app/views/rent_mailer/rent_confirmation.html.slim
@@ -1,13 +1,14 @@
-h1 Rent confirmation for #{@book.title}.
-h4 #{@user.first_name}, You have succesfully rented #{@book.title}.
+h1 = t('.title' , title: @book.title)
 
-p Info about the book:
+h4 = t('.subtitle', name: @user.first_name, title: @book.title)
+
+p = t('.info')
 ul
-  li Author: #{@book.author}
-  li Publisher: #{@book.publisher}
-  li Year: #{@book.year}
-  li Genre: #{@book.genre}
+  li = t('.author', author: @book.author)
+  li = t('.publisher', publisher: @book.publisher)
+  li = t('.year', year: @book.year)
+  li = t('.genre', genre: @book.genre)
 
-p Remember that the rent is from #{@rent.from_date} to #{@rent.to_date}
+p = t('.foot1', from: @rent.from_date, to: @rent.to_date)
 hr
-p Rent confirmation created at: #{@rent.created_at}
+p = t('.foot2', created_at: @rent.created_at)

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,7 @@ module WBooksAPI
 
     # run bundle exec sidekiq -q default -q mailers
     config.active_job.queue_adapter = :sidekiq
+
+    I18n.available_locales = [:en, :es]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,14 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   hello: "Hello world"
+
+  rent_mailer:
+    rent_confirmation:
+      title: 'Rent confirmation for %{title}'
+      subtitle: "%{name}, you have succesfully rented %{title}"
+      info: 'Additional info about the book'
+      author: "Author: %{author}"
+      publisher: "Publisher: %{publisher}"
+      year: "Year: %{year}"
+      genre: "Genre: %{genre}"
+      foot1: "Remember that the rent is from %{from} to %{to}"
+      foot2: "Rent confirmation created at: %{created_at}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
 
   rent_mailer:
     rent_confirmation:
-      title: 'Rent confirmation for %{title}'
+      title: "Rent confirmation for %{title}"
       subtitle: "%{name}, you have succesfully rented %{title}"
       info: 'Additional info about the book'
       author: "Author: %{author}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,2 @@
+en:
+  hello: "Hola Mundo"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,7 +3,7 @@ es:
 
   rent_mailer:
     rent_confirmation:
-      title: 'Confirmación de renta para %{title}'
+      title: "Confirmación de renta para %{title}"
       subtitle: "%{name}, has rentado satisfactoriamente %{title}"
       info: 'Información adicional sobre el libro'
       author: "Autor: %{author}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,2 +1,14 @@
-en:
+es:
   hello: "Hola Mundo"
+
+  rent_mailer:
+    rent_confirmation:
+      title: 'Confirmación de renta para %{title}'
+      subtitle: "%{name}, has rentado satisfactoriamente %{title}"
+      info: 'Información adicional sobre el libro'
+      author: "Autor: %{author}"
+      publisher: "Editor: %{publisher}"
+      year: "Año: %{year}"
+      genre: "Genero: %{genre}"
+      foot1: "Recuerde que su renta es desde %{from} hasta %{to}"
+      foot2: "Confirmación de renta creada el: %{created_at}"

--- a/db/migrate/20181001210527_add_locale_to_user.rb
+++ b/db/migrate/20181001210527_add_locale_to_user.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :locale, :string, default: "en"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180925141752) do
+ActiveRecord::Schema.define(version: 20181001210527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20180925141752) do
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
     t.text "tokens"
+    t.string "locale", default: "en"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end


### PR DESCRIPTION
### Summary
- Added the `locale` column in users
- Changed the fixed string literals with I18n `t` function
- Added english and spanish email literals


### Trello card
https://trello.com/c/kpVxQMlV/25-internacionalizar-el-email